### PR TITLE
E2E: Retrigger ACB Pipeline on latest main

### DIFF
--- a/specs/.e2e_trigger.md
+++ b/specs/.e2e_trigger.md
@@ -1,0 +1,3 @@
+# E2E Trigger
+
+This file exists only to create a fresh commit that triggers the ACB Pipeline end-to-end on `specs/**` changes.


### PR DESCRIPTION
This PR creates a fresh `specs/**` change to retrigger the ACB Pipeline end-to-end on top of the latest `main` (includes the constraints-based dependency install + pipeline smoke tests from PR #34).

Changes:
- Adds `specs/.e2e_trigger.md` (no functional impact; trigger-only).

Expected outcome:
- ACB Pipeline runs end-to-end (spec_validator → strategy_reviewer → ack_gate → aider_builder → quality gates → QC evaluation → artifacts posted).

If this run fails, we will capture the first failing log line and delegate the narrow fix to Copilot in a follow-up PR.