### PR TITLE
test: verify QC upload fix — files/update + files/read gate

### DIFF
--- a/.github/CI_TRIGGER
+++ b/.github/CI_TRIGGER
@@ -1,0 +1,2 @@
+QC upload fix verification run — files/update + files/read gate
+Triggered: 2026-03-08


### PR DESCRIPTION
## What this PR tests

CI trigger to confirm the two-part QC upload fix produces **different backtest metrics per strategy** (the root cause of the identical-results bug).

## Root cause fixed (committed to `main` via `b280c5e`)

| | Before | After |
|---|---|---|
| Upload method | `files/create` with `strategy_file.name` | `files/update` targeting `main.py` |
| Verification | None | `files/read` 120-char prefix check before compile |
| Entry point | Side file QC ignored | `main.py` — QC's actual execution entry point |

**Why it broke:** QC injects a default `main.py` stub on project creation. `files/create` with a non-`main.py` filename added a second file QC never executes — the default stub ran every time, producing identical metrics across all strategies.

## What to watch in CI
- `qc_backtest_pipeline.yml` should complete without `QCUploadVerifyError`
- Backtest metrics should differ from prior cached identical values
- No `AUTH ERROR`

## Merge plan
Do **not** merge — CI trigger only. Will close after run confirms fix.