### PR TITLE
ci: trigger gemini_builder — DAC first run on vwap_probe.yaml

### DIFF
--- a/specs/vwap_probe.yaml
+++ b/specs/vwap_probe.yaml
@@ -64,4 +64,4 @@ notes: |
     4. pre_commit_gates passes or surfaces clear fixable errors
     5. qc_upload_eval runs (stub or real) without crash
   If all 5 pass -> proceed to full vwap-mean-reversion-mes-tqqq.yaml.
-  # retriggered: 2026-03-10T22:09 UTC - DAC first run (gemini_builder)
+  # retriggered: 2026-03-11T05:26 UTC - after google-genai SDK + model name fix


### PR DESCRIPTION
## Purpose

This PR touches `specs/vwap_probe.yaml` (retrigger comment only — no logic changes) to fire the `gemini_builder.yml` workflow on push.

This is the **first live run of the Direct API Coder (DAC)** — `gemini_builder.py` will:
1. Load `specs/vwap_probe.yaml`
2. Build a QC LEAN strategy via Gemini Flash (iterations 1–3) / Pro-exp (iterations 4–5)
3. Feed exact LEAN compile errors back into each iteration
4. Write `strategies/vwap_probe/main.py` only if syntax + LEAN compile + backtest constraints all pass

## What to watch
- CI step: **Build strategy with Gemini** — watch iteration logs
- Expected: LEAN compile error on iteration 1 is normal; feedback loop should converge
- Success: `strategies/vwap_probe/main.py` committed back to this branch

## References
- Architecture: UNI-95
- CONTEXT_SEED: UNI-91 (v12)
- PR #122 (DAC merged): https://github.com/AmandipSidhu/infinity-lab-public/pull/122

**Do not merge this PR** — it exists only to trigger CI. Close after run completes.