### PR TITLE
ci: trigger gemini_builder v2 — google-genai SDK + 2.5 models

### DIFF
--- a/specs/vwap_probe.yaml
+++ b/specs/vwap_probe.yaml
@@ -64,4 +64,4 @@ notes: |
     4. pre_commit_gates passes or surfaces clear fixable errors
     5. qc_upload_eval runs (stub or real) without crash
   If all 5 pass -> proceed to full vwap-mean-reversion-mes-tqqq.yaml.
-  # retriggered: 2026-03-07T06:07 UTC - retrigger after IndentationError fix in run_tier_3
+  # retriggered: 2026-03-11T05:38 UTC - v2 branch from fixed main (google-genai + 2.5 models)


### PR DESCRIPTION
## Purpose
CI trigger only — do not merge.

Fresh branch from fixed `main` (commit `f8fd79e`):
- `google-genai>=1.0.0` SDK (replaces deprecated `google-generativeai`)
- `gemini-2.5-flash-preview-04-17` (replaces dead `gemini-2.0-flash`)
- `gemini-2.5-pro-preview-03-25` (replaces 404 `gemini-2.0-pro-exp`)

PR #123 closed — this is the clean retrigger.