### PR TITLE
ci: trigger gemini_builder v3 — all infra fixes applied

### DIFF
--- a/specs/vwap_probe.yaml
+++ b/specs/vwap_probe.yaml
@@ -64,4 +64,4 @@ notes: |
     4. pre_commit_gates passes or surfaces clear fixable errors
     5. qc_upload_eval runs (stub or real) without crash
   If all 5 pass -> proceed to full vwap-mean-reversion-mes-tqqq.yaml.
-  # retriggered: 2026-03-07T06:07 UTC - retrigger after IndentationError fix in run_tier_3
+  # retriggered: 2026-03-11T05:45 UTC - v3 from main with requirements.txt install + genai SDK + 2.5 models


### PR DESCRIPTION
## CI trigger only — do not merge.

Fresh branch from `main` @ `71f40ce` — contains all 3 infra fixes:
1. `google-genai>=1.0.0` in `requirements.txt`
2. `gemini_builder.py` uses `google.genai` SDK + `gemini-2.5-flash/pro` models
3. Workflow installs `pip install -r requirements.txt` (no more hardcoded list)

PR #123 and #124 closed. This is the clean run.