### PR TITLE
ci: trigger gemini_builder v4 — all infra fixes

### DIFF
--- a/specs/vwap_probe.yaml
+++ b/specs/vwap_probe.yaml
@@ -64,4 +64,4 @@ notes: |
     4. pre_commit_gates passes or surfaces clear fixable errors
     5. qc_upload_eval runs (stub or real) without crash
   If all 5 pass -> proceed to full vwap-mean-reversion-mes-tqqq.yaml.
-  # retriggered: 2026-03-07T06:07 UTC - retrigger after IndentationError fix in run_tier_3
+  # retriggered: 2026-03-11T05:54 UTC - v4: all infra fixes (genai SDK + stable models + requirements.txt)


### PR DESCRIPTION
## CI trigger only — do not merge.

Fresh branch from `main` @ `04584d0` — all 4 fixes:
1. `google-genai>=1.0.0` in `requirements.txt`
2. `gemini_builder.py` uses `google.genai` SDK
3. Workflow uses `pip install -r requirements.txt`
4. Models: `gemini-2.5-flash` / `gemini-2.5-pro` (stable aliases, verified from live docs 2026-03-10)

PRs #123, #124, #125 all closed.