### PR TITLE
chore: opt into Node.js 24 actions runner (gate0 deprecation warning)

### DIFF
--- a/.github/workflows/gate0_qc_mcp_verify.yml
+++ b/.github/workflows/gate0_qc_mcp_verify.yml
@@ -3,6 +3,9 @@ name: GATE-0 QC MCP Verify
 on:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   verify-qc-mcp:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Gate 0 CI run produced a Node.js 20 deprecation warning:

> Node.js 20 actions are deprecated. `actions/checkout@v4`, `actions/setup-python@v5`, `actions/upload-artifact@v4` will be forced to run with Node.js 24 starting June 2nd, 2026.

## Fix

Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the workflow `env` level. This opts the workflow into Node.js 24 immediately, suppressing the warning and ensuring we're running on the same runtime that GitHub will enforce after June 2, 2026.

No logic changes — workflow body is identical to `main`.

## Note on exit code 1

The exit code 1 failure is a separate issue: `BACKTEST_ID` is stale (QC purges raw order blobs after ~10 days). That requires a fresh backtest ID from the QC account and is tracked separately.